### PR TITLE
#135 updated error handling on confirmation wait

### DIFF
--- a/src/integrationTest/java/com/kryptokrauts/aeternity/test/integration/BaseTest.java
+++ b/src/integrationTest/java/com/kryptokrauts/aeternity/test/integration/BaseTest.java
@@ -123,7 +123,7 @@ public abstract class BaseTest {
     vertx.close();
   }
 
-  private static String getAeternityBaseUrl() throws ConfigurationException {
+  protected static String getAeternityBaseUrl() throws ConfigurationException {
     String aeternityBaseUrl = System.getenv(AETERNITY_BASE_URL);
     if (aeternityBaseUrl == null) {
       throw new ConfigurationException("ENV variable missing: AETERNITY_BASE_URL");

--- a/src/main/java/com/kryptokrauts/aeternity/sdk/service/transaction/impl/TransactionServiceImpl.java
+++ b/src/main/java/com/kryptokrauts/aeternity/sdk/service/transaction/impl/TransactionServiceImpl.java
@@ -24,6 +24,7 @@ import com.kryptokrauts.aeternity.sdk.service.transaction.type.model.PayingForTr
 import com.kryptokrauts.aeternity.sdk.util.ByteUtils;
 import com.kryptokrauts.aeternity.sdk.util.EncodingUtils;
 import com.kryptokrauts.aeternity.sdk.util.SigningUtil;
+import io.netty.util.internal.StringUtil;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 import java.math.BigInteger;
@@ -303,6 +304,12 @@ public class TransactionServiceImpl implements TransactionService {
   private PostTransactionResult waitUntilTransactionIsIncludedInBlock(
       PostTransactionResult postTransactionResult) {
     if (postTransactionResult != null) {
+      if (!StringUtil.isNullOrEmpty(postTransactionResult.getRootErrorMessage())) {
+        throw new AException(
+            "An error occured while waiting for transaction to be included in block: "
+                + postTransactionResult.getRootErrorMessage(),
+            postTransactionResult.getThrowable());
+      }
       String transactionHash = postTransactionResult.getTxHash();
       int currentBlockHeight = -1;
       SignedTx includedTransaction = null;


### PR DESCRIPTION
Error handling unfortunately does not deliver more details, but useless null check removed in favour to providing an exception with a more accordingly error message